### PR TITLE
Refresh about content and AI blog focus

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -217,50 +217,15 @@ h3 {
   padding: clamp(4rem, 7vw, 6.5rem) 0;
 }
 
-.about-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1.75rem;
-  margin-bottom: 3rem;
-}
-
-.about-card {
+.about-text {
   background: var(--card-bg);
   border: 1px solid var(--card-border);
   border-radius: var(--radius-md);
-  padding: 1.75rem;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
   box-shadow: var(--shadow);
-}
-
-.timeline {
-  border-left: 2px solid var(--card-border);
-  margin-left: 1rem;
-  padding-left: 1.5rem;
   display: grid;
-  gap: 1.5rem;
-}
-
-.timeline-item {
-  position: relative;
-}
-
-.timeline-item::before {
-  content: "";
-  position: absolute;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: var(--accent);
-  border: 3px solid #0f172a;
-  left: -2.35rem;
-  top: 0.35rem;
-}
-
-.timeline-year {
-  font-weight: 600;
-  display: inline-block;
-  margin-bottom: 0.35rem;
-  color: var(--text);
+  gap: 1.25rem;
+  max-width: 880px;
 }
 
 .blog {
@@ -289,15 +254,6 @@ h3 {
 .blog-card:focus-within {
   transform: translateY(-4px);
   border-color: rgba(56, 189, 248, 0.6);
-}
-
-.blog-category {
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--accent);
-  margin-bottom: -0.5rem;
 }
 
 .text-link {

--- a/index.html
+++ b/index.html
@@ -32,11 +32,11 @@
       <section class="hero" id="home">
         <div class="container hero-content">
           <div class="hero-copy">
-            <p class="eyebrow">Entreprenrur • Engineer • Consultant • Writer</p>
+            <p class="eyebrow">Entrepreneur • Engineer • Consultant • Writer</p>
             <h1>Shaping AI strategy for businesses and sharing what I learn.</h1>
             <p class="lead">
-              Hi, I'm Aaryan Shah - technologist, strategist, and life-long builder. On this site you'll find my story and perspective on
-              AI, Strategy, and lifelong learning.
+              Hi, I'm Aaryan Shah — technologist, strategist, and life-long builder. On this site you'll find my story and
+              perspective on AI, strategy, and lifelong learning.
             </p>
             <div class="hero-cta">
               <a class="button primary" href="#about">About me</a>
@@ -53,48 +53,30 @@
         <div class="container about-content">
           <div class="section-heading">
             <p class="eyebrow">About</p>
-            <h2>From tinkering with circuits to architecting AI systems.</h2>
+            <h2>Bridging entrepreneurial instincts with AI innovation.</h2>
           </div>
-          <div class="about-grid">
-            <article class="about-card">
-              <h3>Who I am</h3>
-              <p>
-                I am a multidisciplinary engineer blending software craftsmanship with a deep
-                curiosity for intelligent systems. I love building products that balance
-                technical rigor with empathy for the people who use them.
-              </p>
-            </article>
-            <article class="about-card">
-              <h3>What I do</h3>
-              <p>
-                At my day job I design machine learning platforms that move research ideas
-                into production. Outside of work I explore product strategy, publish
-                technical tutorials, and mentor aspiring ML engineers.
-              </p>
-            </article>
-            <article class="about-card">
-              <h3>How I work</h3>
-              <p>
-                I believe the best teams are collaborative, data-informed, and
-                mission-driven. My process centers on clarifying the problem, iterating on
-                experiments, and communicating insights clearly.
-              </p>
-            </article>
-          </div>
-
-          <div class="timeline">
-            <div class="timeline-item">
-              <span class="timeline-year">2024</span>
-              <p>Leading cross-functional initiatives to deploy trustworthy AI systems.</p>
-            </div>
-            <div class="timeline-item">
-              <span class="timeline-year">2022</span>
-              <p>Shipped a recommendation engine powering millions of daily experiences.</p>
-            </div>
-            <div class="timeline-item">
-              <span class="timeline-year">2019</span>
-              <p>Completed B.S. in Computer Science with a focus on machine learning.</p>
-            </div>
+          <div class="about-text">
+            <p>
+              Growing up in an entrepreneurial family, I saw firsthand how innovation and technology transform businesses. That
+              early exposure sparked a passion that led me to graduate first in my class at NIT Trichy, earn a Master’s in Electrical
+              &amp; Computer Engineering at Georgia Tech, and work on cutting-edge machine learning research sponsored by the U.S.
+              Department of Defense.
+            </p>
+            <p>
+              Today, I help organizations unlock growth at the intersection of AI and business strategy. At McKinsey, I’ve led
+              projects for Fortune 10–50 companies — from building an AI optimization engine that uncovered $50M+ in value, to
+              driving 30% churn reduction with AI-powered retention strategies, to advising executives on GenAI adoption and cloud
+              strategy.
+            </p>
+            <p>
+              What excites me is the opportunity to bridge technology and business: designing solutions that are both technically
+              rigorous and simple enough for decision-makers to act on. My expertise spans AI strategy, product incubation, and
+              go-to-market execution — with a focus on helping organizations scale AI responsibly and effectively.
+            </p>
+            <p>
+              Beyond work, I’m passionate about entrepreneurship, mentoring, and exploring how emerging technologies will reshape
+              the way we live and work.
+            </p>
           </div>
         </div>
       </section>
@@ -103,38 +85,35 @@
         <div class="container blog-content">
           <div class="section-heading">
             <p class="eyebrow">Blog</p>
-            <h2>Recent writing on AI, product, and personal growth.</h2>
+            <h2>Latest thinking on GenAI and intelligent systems.</h2>
             <p class="lead">
-              I publish essays and guides that demystify complex topics and share
-              lessons from building real-world AI systems. Here are a few favorites.
+              I write about how organizations can harness artificial intelligence to create meaningful business value while
+              building responsibly.
             </p>
           </div>
 
           <div class="blog-grid">
             <article class="blog-card">
-              <p class="blog-category">AI &amp; ML</p>
-              <h3><a href="#">Designing human-centered ML systems</a></h3>
+              <h3><a href="#">The GenAI playbook for enterprise leaders</a></h3>
               <p>
-                A framework for aligning model objectives with user needs while balancing
-                performance, fairness, and interpretability.
+                Practical guidance on identifying high-impact use cases, aligning teams, and proving value quickly when adopting
+                generative AI across the organization.
+              </p>
+              <a class="text-link" href="#">Read the GenAI blog</a>
+            </article>
+            <article class="blog-card">
+              <h3><a href="#">Operationalizing responsible AI at scale</a></h3>
+              <p>
+                A roadmap for embedding governance, measurement, and human oversight into AI initiatives without slowing down
+                innovation.
               </p>
               <a class="text-link" href="#">Read more</a>
             </article>
             <article class="blog-card">
-              <p class="blog-category">Product Strategy</p>
-              <h3><a href="#">Turning research into product impact</a></h3>
+              <h3><a href="#">Designing AI products your customers trust</a></h3>
               <p>
-                Lessons learned from partnering with cross-functional teams to ship
-                machine learning features that customers love.
-              </p>
-              <a class="text-link" href="#">Read more</a>
-            </article>
-            <article class="blog-card">
-              <p class="blog-category">Career</p>
-              <h3><a href="#">The engineer's guide to lifelong learning</a></h3>
-              <p>
-                Tactics for staying curious, leveling up your skills, and building a body of
-                work that compounds over time.
+                Lessons from the field on translating complex models into intuitive experiences that drive adoption and lasting
+                customer value.
               </p>
               <a class="text-link" href="#">Read more</a>
             </article>


### PR DESCRIPTION
## Summary
- polish the hero introduction and ensure the portrait uses the uploaded title image
- replace the about timeline with a narrative biography that reflects entrepreneurial and AI strategy experience
- refocus the blog section on GenAI and AI topics while simplifying the layout styling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf22c90e3483219cb641adf5a51f55